### PR TITLE
Add config-based JWT key

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -34,7 +34,11 @@ builder.Services.AddElsa(elsa =>
     // Identity & API
     elsa.UseIdentity(identity =>
     {
-        identity.TokenOptions = options => options.SigningKey = "turXh889xVusqCRBz3SIzRapD90e6hgAw/1QYvdpKUo=";
+        var signingKey = builder.Configuration["Jwt:SigningKey"];
+        if (string.IsNullOrWhiteSpace(signingKey))
+            throw new InvalidOperationException("JWT signing key is not configured.");
+
+        identity.TokenOptions = options => options.SigningKey = signingKey;
         identity.UseAdminUserProvider();
     });
     // Configure ASP.NET authentication/authorization.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,21 @@
+# Elsa Server
+
+This project runs an Elsa Workflow server. Configuration values are stored in `appsettings.json` and can be overridden using environment variables.
+
+## API security
+
+The application expects a JWT signing key to be provided via configuration under `Jwt:SigningKey`. For production deployments, store this value in an environment variable (for example `Jwt__SigningKey`) or a secrets store. Never commit real keys to version control.
+
+```json
+// appsettings.json
+"Jwt": {
+  "SigningKey": "CHANGE_ME"
+}
+```
+
+To run the server locally you can set the variable before starting the application:
+
+```bash
+export Jwt__SigningKey="your-secret-key"
+```
+

--- a/appsettings.json
+++ b/appsettings.json
@@ -2,7 +2,10 @@
   "ConnectionStrings": {
     "Elsa": "Server=localhost; Database=NewElsaDb; Trusted_Connection=True; TrustServerCertificate=True;",
     "Redis": "localhost:6379",
-    "Hangfire": "Server=localhost; Database=NewHangFireDb; Trusted_Connection=True; TrustServerCertificate=True;"
+  "Hangfire": "Server=localhost; Database=NewHangFireDb; Trusted_Connection=True; TrustServerCertificate=True;"
+  },
+  "Jwt": {
+    "SigningKey": "CHANGE_ME"
   },
   "Redis": {
     "Database": "1" // The database number


### PR DESCRIPTION
## Summary
- load JWT signing key from configuration instead of hardcoding
- add Jwt settings placeholder
- document configuration of signing key

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_685bb1a115d4832a9ed9203059054f17